### PR TITLE
Closes #86: Allow alternate identifiers to be used

### DIFF
--- a/app/Controllers/Http/ParticipantController.js
+++ b/app/Controllers/Http/ParticipantController.js
@@ -144,7 +144,10 @@ class ParticipantController {
    * @param {Response} ctx.response
    */
   async store ({ request, response, transform }) {
-    const data = request.only(['name', 'identifier', 'active'])
+    const data = request.only(['name', 'identifier', 'alternate_identifier', 'meta', 'active'])
+    if (data.meta === '') {
+      delete data.meta
+    }
     const ptcp = await Participant.create(data)
     await ptcp.reload() // Refresh data otherwise some parameters are missing
     response.status(201)
@@ -304,7 +307,7 @@ class ParticipantController {
    */
   async update ({ params, request, response, transform }) {
     const ptcp = await Participant.findOrFail(params.id)
-    const data = request.only(['name', 'identifier', 'active', 'meta'])
+    const data = request.only(['name', 'identifier', 'alternate_identifier', 'active', 'meta'])
     ptcp.merge(data)
     try {
       await ptcp.save()

--- a/app/Controllers/Http/ParticipantController.js
+++ b/app/Controllers/Http/ParticipantController.js
@@ -815,6 +815,46 @@ class ParticipantController {
 
     return response.noContent()
   }
+
+  /**
+  * @swagger
+  * /participants/{identifier}/canonical:
+  *   get:
+  *     tags:
+  *       - Participants
+  *     summary: >
+  *         Retrieves the canonical identifier for a participant.
+  *     parameters:
+  *       - in: path
+  *         name: identifier
+  *         required: true
+  *         type: string
+  *         description: The identifier of the participant to retrieve
+  *     responses:
+  *       200:
+  *         description: The participant's canonical identifier.
+  *         schema:
+  *           properties:
+  *             data:
+  *               type: object
+  *               properties:
+  *                 identifier:
+  *                   type: string
+  *                   example: abc
+  *       404:
+  *         description: The participant with the specified identifier was not found.
+  *       default:
+  *         description: Unexpected error
+  */
+  async canonicalIdentifier ({ params }) {
+    const { identifier } = params
+    const result = await Participant.query()
+      .select('identifier')
+      .where('identifier', identifier)
+      .orWhere('alternate_identifier', identifier)
+      .firstOrFail()
+    return { data: { identifier: result.identifier } }
+  }
 }
 
 module.exports = ParticipantController

--- a/app/Validators/SaveParticipant.js
+++ b/app/Validators/SaveParticipant.js
@@ -6,14 +6,16 @@ class SaveParticipant {
     return {
       // validation rules
       name: 'required|max:50',
-      identifier: `required|unique:participants,identifier,id,${ptcpId}`,
+      identifier: `required|different:alternate_identifier|unique:participants,identifier,id,${ptcpId}|unique:participants,alternate_identifier,id,${ptcpId}`,
+      alternate_identifier: `required|different:identifier|unique:participants,identifier,id,${ptcpId}|unique:participants,alternate_identifier,id,${ptcpId}`,
       meta: 'json'
     }
   }
 
   get messages () {
     return {
-      'identifier.unique': 'This identifier is already used.'
+      'identifier.unique': 'This identifier is already used.',
+      'alternate_identifier.unique': 'This identifier is already used.'
     }
   }
 }

--- a/database/migrations/1618169781120_add_alternate_identifier_schema.js
+++ b/database/migrations/1618169781120_add_alternate_identifier_schema.js
@@ -1,0 +1,20 @@
+'use strict'
+
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema')
+
+class AddAlternateIdentifierSchema extends Schema {
+  up () {
+    this.alter('participants', (table) => {
+      table.string('alternate_identifier').unique()
+    })
+  }
+
+  down () {
+    this.alter('participants', (table) => {
+      table.dropColumn('alternate_identifier')
+    })
+  }
+}
+
+module.exports = AddAlternateIdentifierSchema

--- a/resources/components/Participants/ParticipantEditData/ParticipantEditData.test.js
+++ b/resources/components/Participants/ParticipantEditData/ParticipantEditData.test.js
@@ -54,13 +54,6 @@ describe('ParticipantEditData', () => {
     expect(wrapper.vm.ptcp).toEqual(participant)
   })
 
-  it('should have the save button disabled if no data is entered', async () => {
-    const wrapper = mountFunc()
-    await flushPromises()
-    const saveBtn = getSaveBtn(wrapper)
-    expect(saveBtn.attributes('disabled')).toBe('disabled')
-  })
-
   it('checks if data is changed when cancelling and shows dialog if it is', async () => {
     const wrapper = mountFunc({
       propsData: {

--- a/resources/components/Participants/ParticipantEditData/ParticipantEditData.vue
+++ b/resources/components/Participants/ParticipantEditData/ParticipantEditData.vue
@@ -6,7 +6,7 @@
       @clicked-no="dialog = false"
     />
     <v-card-text class="fill-height">
-      <v-form ref="form" v-model="validates" @submit.prevent="save">
+      <v-form ref="form" v-model="validates" lazy-validation @submit.prevent="save">
         <v-text-field
           v-model="ptcp.name"
           :rules="validation.name"
@@ -22,6 +22,15 @@
           :label="$t('participants.fields.identifier.label')"
           @input="removeErrors('identifier')"
         />
+
+        <v-text-field
+          v-model="ptcp.alternate_identifier"
+          :rules="validation.alternate_identifier"
+          :error-messages="errors.alternate_identifier"
+          :label="$t('participants.fields.alternate_identifier.label')"
+          @input="removeErrors('alternate_identifier')"
+        />
+
         <v-textarea
           :value="metaToYaml"
           no-resize
@@ -59,6 +68,7 @@ import servererrors from '@/mixins/servererrors'
 const EMPTY_VALUES = {
   name: '',
   identifier: '',
+  alternate_identifier: '',
   meta: '',
   active: true
 }
@@ -96,7 +106,11 @@ export default {
             this.$t('participants.fields.name.errors.maxLength') + this.maxNameLength
         ],
         identifier: [
-          v => !isEmpty(v) || this.$t('participants.fields.identifier.errors.notEmpty')
+          v => !isEmpty(v) || this.$t('participants.fields.identifier.errors.notEmpty'),
+          v => v !== this.ptcp.alternate_identifier || this.$t('participants.fields.identifier.errors.sameAsAlt')
+        ],
+        alternate_identifier: [
+          v => v !== this.ptcp.identifier || this.$t('participants.fields.alternate_identifier.errors.sameAsPrimary')
         ]
       }
     }

--- a/resources/components/Participants/ParticipantViewData/ParticipantViewData.vue
+++ b/resources/components/Participants/ParticipantViewData/ParticipantViewData.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fill-height d-flex flex-column">
-    <v-card-text class="fill-height" style="max-height:340px; overflow:auto">
+    <v-card-text class="fill-height" style="max-height:420px; overflow:auto">
       <template v-for="(value, field) in listable(participant)">
         <v-row
           v-if="field !== 'meta'"
@@ -91,7 +91,8 @@ export default {
     }
   },
   methods: {
-    listable: ptcp => pick(ptcp, ['name', 'identifier', 'meta', 'active', 'created_at', 'updated_at']),
+    listable: ptcp => pick(ptcp, ['name', 'identifier', 'alternate_identifier', 'meta', 'active',
+      'created_at', 'updated_at']),
     label (val) {
       return this.$t(`participants.${val}`)
     },

--- a/resources/components/Participants/ParticipantsList/ParticipantsList.vue
+++ b/resources/components/Participants/ParticipantsList/ParticipantsList.vue
@@ -76,7 +76,7 @@
       <v-expansion-panel-content>
         <v-row>
           <v-col cols="12" md="6">
-            <v-card outlined class="fill-height d-flex flex-column" height="450">
+            <v-card outlined class="fill-height d-flex flex-column" height="525">
               <v-card-title class="subtitle-1 blue-grey lighten-5">
                 {{ $t('common.properties') }}
               </v-card-title>

--- a/resources/lang/en-US/participants.js
+++ b/resources/lang/en-US/participants.js
@@ -1,6 +1,7 @@
 export default {
   search: 'Search participants by name or identifier',
   identifier: 'Identifier',
+  alternate_identifier: 'Alt. identifier',
   participations: 'Participations',
   meta: 'Extra info',
   status: 'Status',
@@ -25,7 +26,15 @@ export default {
     identifier: {
       label: 'Identifier',
       errors: {
-        notEmpty: 'identifier cannot be empty'
+        notEmpty: 'identifier cannot be empty',
+        sameAsAlt: 'Must be different from alternate identifier'
+      }
+    },
+    alternate_identifier: {
+      label: 'Alternate identifier',
+      errors: {
+        notEmpty: 'identifier cannot be empty',
+        sameAsPrimary: 'Must be different from identifier'
       }
     }
   },

--- a/resources/models/Participant.js
+++ b/resources/models/Participant.js
@@ -11,6 +11,7 @@ export default class Participant extends Model {
       id: this.number(null),
       name: this.string(''),
       identifier: this.string(''),
+      alternate_identifier: this.string(''),
       active: this.boolean(true),
       meta: this.attr(''),
       studies_count: this.number(0),

--- a/resources/pages/dashboard/participants.vue
+++ b/resources/pages/dashboard/participants.vue
@@ -182,7 +182,9 @@ export default {
       if (this.saving) { return }
       this.saving = true
       try {
-        const payload = pick(ptcpData, ['$id', 'id', 'name', 'identifier', 'meta', 'active'])
+        const payload = pick(ptcpData, [
+          '$id', 'id', 'name', 'identifier', 'alternate_identifier', 'meta', 'active'
+        ])
         if (!isString(payload.meta)) {
           payload.meta = JSON.stringify(payload.meta)
         }

--- a/resources/test/__snapshots__/components/Participants/ParticipantEditData/ParticipantEditData.snap.js
+++ b/resources/test/__snapshots__/components/Participants/ParticipantEditData/ParticipantEditData.snap.js
@@ -35,12 +35,27 @@ exports[`ParticipantEditData matches its snapshot 1`] = `
           </div>
         </div>
       </div>
+      <div class="v-input theme--light v-text-field">
+        <div class="v-input__control">
+          <div class="v-input__slot">
+            <div class="v-text-field__slot">
+              <label class="v-label theme--light" for="input-9" style="left: 0px; position: absolute;">participants.fields.alternate_identifier.label</label>
+              <input id="input-9" type="text">
+            </div>
+          </div>
+          <div class="v-text-field__details">
+            <div class="v-messages theme--light">
+              <transition-group-stub class="v-messages__wrapper" name="message-transition" tag="div"></transition-group-stub>
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="v-input v-textarea v-textarea--no-resize theme--light v-text-field">
         <div class="v-input__control">
           <div class="v-input__slot">
             <div class="v-text-field__slot">
-              <label class="v-label theme--light" for="input-9" style="left: 0px; position: absolute;">Extra information</label>
-              <textarea id="input-9" rows="3"></textarea>
+              <label class="v-label theme--light" for="input-12" style="left: 0px; position: absolute;">Extra information</label>
+              <textarea id="input-12" rows="3"></textarea>
             </div>
           </div>
           <div class="v-text-field__details">
@@ -54,14 +69,14 @@ exports[`ParticipantEditData matches its snapshot 1`] = `
         <div class="v-input__control">
           <div class="v-input__slot">
             <div class="v-input--selection-controls__input">
-              <input aria-checked="true" aria-disabled="false" id="input-12" role="switch" type="checkbox" value>
+              <input aria-checked="true" aria-disabled="false" id="input-15" role="switch" type="checkbox" value>
               <div class="v-input--selection-controls__ripple primary--text"></div>
               <div class="v-input--switch__track theme--light primary--text"></div>
               <div class="v-input--switch__thumb theme--light primary--text">
                 <transition-stub mode="out-in" name="fab-transition"></transition-stub>
               </div>
             </div>
-            <label class="v-label theme--light" for="input-12" style="left: 0px; position: relative;">participants.active</label>
+            <label class="v-label theme--light" for="input-15" style="left: 0px; position: relative;">participants.active</label>
           </div>
         </div>
       </div>

--- a/resources/test/__snapshots__/components/Participants/ParticipantViewData/ParticipantViewData.snap.js
+++ b/resources/test/__snapshots__/components/Participants/ParticipantViewData/ParticipantViewData.snap.js
@@ -2,7 +2,7 @@
 
 exports[`ParticipantViewData wrapper matches its snapshot 1`] = `
 <div class="fill-height d-flex flex-column">
-  <div class="v-card__text fill-height" style="max-height: 340px; overflow: auto;">
+  <div class="v-card__text fill-height" style="max-height: 420px; overflow: auto;">
     <div class="row body-1">
       <div class="font-weight-medium col-md-4 col-6">
         participants.name:

--- a/start/routes.js
+++ b/start/routes.js
@@ -90,6 +90,7 @@ Route.group(() => {
   Route.post('/auth/password/reset/:token', 'UserController.updatePasswordByToken').as('users.reset_password')
   Route.post('/auth/email/verify/:token', 'UserController.verifyEmailAddress').as('users.verify_email')
 
+  Route.get('participants/:identifier/canonical', 'ParticipantController.canonicalIdentifier')
   Route.get('participants/:identifier/announce', 'ParticipantController.announce').as('participants.announce')
   Route.get('/participants/:identifier/:studyID/currentjob', 'ParticipantController.fetchJob')
     .as('participants.fetch_job')


### PR DESCRIPTION
This is a rough working version of allowing alternate identifiers. Currently implemented:

- Endpoint `GET /participants/{identifier}/canonical` to retrieve the canonical identifier.
- UI elements for adding alternate identifiers to participants.
- Input validation:
    -  Is the supplied identifier unique for both identifier and alternate_identifier fields? (there should be no duplicates in either column in the database) (NEEDS TO BE MORE THOROUGHLY TESTED)
    - Are the values of identifier and alternate_identifier in the form not the same?

TODOs:
- If the value of `alternate_indentifier` is `null`, it is shown as null in viewing panel, and the default value of the field in the edit panel also shows null. This of course should be empty in both cases (or ommited in the viewing panel).
- More @smathot ?
