### PR TITLE
Add .npmrc with node-options=--openssl-legacy-provider

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-options=--openssl-legacy-provider


### PR DESCRIPTION
It's necessary for modern node versions.