### PR TITLE
Database seeder

### DIFF
--- a/app/Controllers/Http/StudyController.js
+++ b/app/Controllers/Http/StudyController.js
@@ -607,7 +607,7 @@ class StudyController {
       return response.status(code).json({ message: e.toString() })
     }
 
-    // Set participants with status 'finished' back started (since new jobs have been added)
+    // Set participants with status 'finished' back to 'started' (since new jobs have been added)
     await study.participants()
       .pivotQuery()
       .where('status_id', 3) // participation status 'finished'

--- a/app/Models/Study.js
+++ b/app/Models/Study.js
@@ -340,14 +340,31 @@ class Study extends Model {
       })
     }
 
+    // Get the variables for the job and convert them to key:value pairs so that the variable name is the
+    // key and the value is its value
+    const vars = job.getRelated('variables')
+    let varData = []
+    if (vars && vars.length) {
+      varData = vars.map(v => ({
+        [v.name]: [v.pivot?.value]
+      }))
+    }
+
     // A job result is stored as JSON in the database and consists of 1) the actual submitted data, 2) some info about the participant,
-    // 3) some info about the job, 4) the variables data.
+    // 3) some info about the job, 4) the variables data, 5) the study ID and name.
     return await this.jobResults().create({
       study_id: this.Id,
       participant_id: ptcpId,
       job_id: jobId,
       data: JSON.stringify({
-        ...variableData,
+        participant_name: ptcp.name,
+        participant_identifier: ptcp.identifier,
+        participant_meta: ptcp.meta,
+        job_id: job.id,
+        job_position: job.position,
+        study_id: this.id,
+        study_name: this.name,
+        ...varData,
         ...data
       })
     })
@@ -355,7 +372,7 @@ class Study extends Model {
 
   /**
    * Checks if a study is finished. If ptcpID is supplied, it will check if that
-   * particular participant has done all jobs for the study. If this parameter is ommitted
+   * particular participant has done all jobs for the study. If this parameter is omitted
    * it will check if there are open jobs for any participant.
    *
    * @param {Number} [ptcpID=null]

--- a/database/migrations/1643093520566_job_results_schema.js
+++ b/database/migrations/1643093520566_job_results_schema.js
@@ -12,10 +12,6 @@ class JobResultSchema extends Schema {
       table.integer('job_id').unsigned()
       table.json('data')
       table.timestamps()
-
-      table.foreign('study_id').references('id').inTable('studies')
-      table.foreign('participant_id').references('id').inTable('participants')
-      table.foreign('job_id').references('id').inTable('jobs')
     })
   }
 

--- a/database/migrations/1643093520566_job_results_schema.js
+++ b/database/migrations/1643093520566_job_results_schema.js
@@ -3,6 +3,12 @@
 /** @type {import('@adonisjs/lucid/src/Schema')} */
 const Schema = use('Schema')
 
+/**
+ * Schema for job results that most importantly store the job result data. 
+ * 
+ * Do not rely on the study_id, participant_id, or job_id - they are not enforced by a foreign key constraint.
+ * A study, participant, or job can be deleted but the related job result data is kept.
+ */
 class JobResultSchema extends Schema {
   up () {
     this.create('job_results', (table) => {


### PR DESCRIPTION
Removes foreign keys from the JobResultSchema (we want to keep them even if there study or participants are deleted) and adds
        participant_name,
        participant_identifier,
        participant_meta,
        job_id,
        job_position,
        study_id,
        study_name
to the 'data' row when it is stored.