### PR TITLE
Make study list sortable (draggable)

### DIFF
--- a/resources/components/Studies/ArchivedStudies/ArchivedStudies.vue
+++ b/resources/components/Studies/ArchivedStudies/ArchivedStudies.vue
@@ -2,6 +2,7 @@
   <studies-list
     :studies="filteredStudies"
     :loading="loading"
+    :active="false"
   />
 </template>
 

--- a/resources/components/Studies/StudiesList/StudiesList.test.js
+++ b/resources/components/Studies/StudiesList/StudiesList.test.js
@@ -48,25 +48,6 @@ describe('StudiesList', () => {
   //   expect(wrapper.findAll('.v-list-item').length).toBe(studies.length)
   // })
 
-  test('Skeleton is shown during loading and hidden afterwards', async () => {
-    const wrapper = mountFunc({
-      propsData: {
-        studies: [],
-        loading: true
-      }
-    })
-    await flushPromises()
-    expect(wrapper.find('.v-skeleton-loader').exists()).toBe(true)
-    expect(wrapper.find('.v-list-item').exists()).toBe(false)
-
-    await wrapper.setProps({
-      studies: [{ id: 1, name: 'Test study', description: 'Description' }],
-      loading: false
-    })
-    expect(wrapper.find('.v-skeleton-loader').exists()).toBe(false)
-    // expect(wrapper.find('.v-list-item').exists()).toBe(true)
-  })
-
   test('Shows new study button and processes clicks on it', async () => {
     const wrapper = mountFunc({
       propsData: {

--- a/resources/components/Studies/StudiesList/StudiesList.vue
+++ b/resources/components/Studies/StudiesList/StudiesList.vue
@@ -15,56 +15,58 @@
       </v-list-item>
     </v-list>
 
-    <v-list v-if="loading" key="loading" three-line class="py-0">
-      <v-skeleton-loader
-        :loading="loading"
-        type="list-item-three-line@8"
-      />
-    </v-list>
-    <v-list
-      v-else
-      key="loaded"
-      max-height="66vh"
-      class="py-0 overflow-y-auto"
-    >
-      <draggable
-        v-model="rows"
-        tag="v-list"
-        handle=".sortHandle"
-        @start="drag = true"
-        @end="drag = false"
+    <transition name="fade" mode="out-in">
+      <v-list v-if="loading" key="loading" two-line class="py-0">
+        <v-skeleton-loader
+          :loading="loading"
+          type="list-item-two-line@8"
+        />
+      </v-list>
+      <v-list
+        v-else
+        key="loaded"
+        max-height="66vh"
+        class="py-0 overflow-y-auto"
       >
-        <v-list-item
-          v-for="(study, i) in rows"
-          :key="i"
-          :to="localePath(`/dashboard/studies/${study.id}`)"
-          nuxt
+        <draggable
+          v-model="rows"
+          tag="v-list"
+          handle=".sortHandle"
+          @start="drag = true"
+          @end="drag = false"
         >
-          <v-btn v-if="showSortHandle" icon class="sortHandle">
-            <v-icon>mdi-drag-horizontal-variant</v-icon>
-          </v-btn>
-          <v-list-item-content class="px-3">
-            <v-list-item-title v-text="study.name" />
-            <v-list-item-subtitle v-text="study.description" />
-          </v-list-item-content>
-          <v-fab-transition>
-            <v-list-item-action v-show="!userIsOwner(study.id)" class="align-self-center">
-              <v-tooltip bottom>
-                <template #activator="{on, attrs}">
-                  <v-icon color="primary" v-bind="attrs" v-on="on">
-                    mdi-share-variant
-                  </v-icon>
-                </template>
-                {{ $t('studies.list.shared_by') }} {{
-                  studyOwners[study.id] && studyOwners[study.id].name
-                }}
-              </v-tooltip>
-            </v-list-item-action>
-          </v-fab-transition>
-        </v-list-item>
-        <v-divider />
-      </draggable>
-    </v-list>
+          <v-list-item
+            v-for="(study, i) in rows"
+            :key="i"
+            :to="localePath(`/dashboard/studies/${study.id}`)"
+            nuxt
+          >
+            <v-btn v-if="showSortHandle" icon class="sortHandle">
+              <v-icon>mdi-drag-horizontal-variant</v-icon>
+            </v-btn>
+            <v-list-item-content class="px-3">
+              <v-list-item-title v-text="study.name" />
+              <v-list-item-subtitle v-text="study.description" />
+            </v-list-item-content>
+            <v-fab-transition>
+              <v-list-item-action v-show="!userIsOwner(study.id)" class="align-self-center">
+                <v-tooltip bottom>
+                  <template #activator="{on, attrs}">
+                    <v-icon color="primary" v-bind="attrs" v-on="on">
+                      mdi-share-variant
+                    </v-icon>
+                  </template>
+                  {{ $t('studies.list.shared_by') }} {{
+                    studyOwners[study.id] && studyOwners[study.id].name
+                  }}
+                </v-tooltip>
+              </v-list-item-action>
+            </v-fab-transition>
+          </v-list-item>
+          <v-divider />
+        </draggable>
+      </v-list>
+    </transition>
   </div>
 </template>
 


### PR DESCRIPTION
Implementation to Ordering studies [#122](https://github.com/open-cogsci/omm-server/issues/122)

* The study order is not persisted in the database but in the browser's local storage. That means that the order can be different from browser to browser.
* Archived studies are not sortable
* If an filter is applied (search field) the study list is not sortable
* Sometimes an error appears in the browser console: Uncaught DOMException: Node.removeChild: The node to be removed is not a child of this node. It's about a known issue: https://github.com/vuetifyjs/vuetify/issues/13457 and can be ignored / has no effect on our app.