### PR TITLE
fix: list of finished jobs to reset not loaded on the first open

### DIFF
--- a/resources/components/Participants/ParticipantsPanel/ParticipantsPanel.vue
+++ b/resources/components/Participants/ParticipantsPanel/ParticipantsPanel.vue
@@ -10,6 +10,7 @@
       v-model="dialog.resetJobs"
       :study-id="study?.id"
       :participant="dialog.selectedParticipant"
+      :finished-jobs="dialog.finishedJobs"
       @jobs-reset="refresh"
     />
     <v-col
@@ -51,6 +52,7 @@
             :loading="loading.initial"
             :fetching-more="loading.participants"
             :study-id="study?.id"
+            :loading-resets="loadingResets"
             @changed-priority="fetchQueue"
             @scroll-end="loadMore"
             @reset-jobs="openResetJobsDialog"
@@ -66,6 +68,7 @@
 import { mapActions } from 'vuex'
 import { keyBy } from 'lodash'
 import { processErrors } from '@/assets/js/errorhandling'
+import { API_PREFIX } from '@/assets/js/endpoints'
 
 export default {
   components: {
@@ -91,7 +94,8 @@ export default {
         download: false,
         manage: false,
         resetJobs: false,
-        selectedParticipant: null
+        selectedParticipant: null,
+        finishedJobs: null
       },
       loading: {
         initial: false,
@@ -106,7 +110,8 @@ export default {
         total: 0
       },
       ptcpListCtrHeight: 0,
-      queue: {}
+      queue: {},
+      loadingResets: {}
     }
   },
   computed: {
@@ -206,10 +211,25 @@ export default {
     setStartpage () {
       this.pagination.page = Math.max(1, Math.ceil(this.participants.length / this.pagination.perPage))
     },
-    openResetJobsDialog ({ participant, studyId }) {
-      if (participant) {
+    async openResetJobsDialog ({ participant, studyId }) {
+      if (!participant) {
+        return
+      }
+      this.$set(this.loadingResets, participant.id, true)
+      try {
+        const response = await this.$axios.get(
+          `${API_PREFIX}/participants/${participant.identifier}/${studyId}/jobs`
+        )
+        const finishedJobs = response.data.data.filter(
+          job => job.pivot && job.pivot.status_id === 3
+        )
         this.dialog.selectedParticipant = participant
+        this.dialog.finishedJobs = finishedJobs
         this.dialog.resetJobs = true
+      } catch (e) {
+        processErrors(e, this.notify)
+      } finally {
+        this.$set(this.loadingResets, participant.id, false)
       }
     }
   }

--- a/resources/components/Participants/ParticipantsPanel/StudyParticipantsList/StudyParticipantsList.vue
+++ b/resources/components/Participants/ParticipantsPanel/StudyParticipantsList/StudyParticipantsList.vue
@@ -51,6 +51,8 @@
                 <v-btn
                   icon
                   small
+                  :loading="loadingResets[item.id]"
+                  :disabled="loadingResets[item.id]"
                   v-bind="attrs"
                   v-on="on"
                   @click.stop="$emit('reset-jobs', { participant: item, studyId })"
@@ -115,6 +117,10 @@ export default {
     editable: {
       type: Boolean,
       default: false
+    },
+    loadingResets: {
+      type: Object,
+      default: () => ({})
     }
   },
   data: () => ({

--- a/resources/components/Participants/dialogs/ResetJobsDialog/ResetJobsDialog.vue
+++ b/resources/components/Participants/dialogs/ResetJobsDialog/ResetJobsDialog.vue
@@ -25,7 +25,7 @@
 
           <v-progress-linear v-if="loading" indeterminate class="mb-4" />
 
-          <div v-else-if="finishedJobs.length === 0">
+          <div v-else-if="dialogFinishedJobs.length === 0">
             {{ $t('participants.jobs.reset.no_finished') }}
           </div>
 
@@ -43,7 +43,7 @@
               </v-list-item-content>
             </v-list-item>
 
-            <v-list-item v-for="job in finishedJobs" :key="job.id">
+            <v-list-item v-for="job in dialogFinishedJobs" :key="job.id">
               <v-list-item-action>
                 <v-checkbox
                   v-model="selectedJobs"
@@ -106,12 +106,16 @@ export default {
     participant: {
       type: [Object, null],
       default: null
+    },
+    finishedJobs: {
+      type: Array,
+      default: () => []
     }
   },
   data () {
     return {
       loading: false,
-      finishedJobs: [],
+      dialogFinishedJobs: [],
       selectedJobs: [],
       selectAll: false,
       showConfirmation: false
@@ -124,13 +128,20 @@ export default {
   },
   watch: {
     value (val) {
-      if (val && this.participant) {
-        this.fetchFinishedJobs()
+      if (val) {
         this.showConfirmation = false
       }
     },
+    finishedJobs: {
+      handler (newVal) {
+        this.dialogFinishedJobs = newVal || []
+        this.selectedJobs = []
+        this.selectAll = false
+      },
+      immediate: true
+    },
     selectedJobs (val) {
-      this.selectAll = val.length === this.finishedJobs.length && this.finishedJobs.length > 0
+      this.selectAll = val.length === this.dialogFinishedJobs.length && this.dialogFinishedJobs.length > 0
     }
   },
   methods: {
@@ -145,7 +156,7 @@ export default {
         const response = await this.$axios.get(
           `${API_PREFIX}/participants/${this.participant.identifier}/${this.studyId}/jobs`
         )
-        this.finishedJobs = response.data.data.filter(
+        this.dialogFinishedJobs = response.data.data.filter(
           job => job.pivot && job.pivot.status_id === 3
         )
         this.selectedJobs = []
@@ -160,7 +171,7 @@ export default {
 
     toggleAll () {
       if (this.selectAll) {
-        this.selectedJobs = this.finishedJobs.map(j => j.id)
+        this.selectedJobs = this.dialogFinishedJobs.map(j => j.id)
       } else {
         this.selectedJobs = []
       }
@@ -173,7 +184,7 @@ export default {
 
       this.loading = true
       try {
-        const positions = this.finishedJobs
+        const positions = this.dialogFinishedJobs
           .filter(j => this.selectedJobs.includes(j.id))
           .map(j => j.position)
 


### PR DESCRIPTION
Closes #218 

The issue description: when a user clicked the "refresh" icon next to a participant to reset finished jobs, the reset dialog opened displaying "No finished jobs found" on the first open, but correctly list the finished jobs on the second click. This occurred likely because the dialog rendered the job list based on an empty or stale state on the first open.

Fix:
- Moved the job fetching logic from the dialog component to its parent (`ParticipantsPanel.vue`). Now, when the "refresh" icon is clicked, the parent fetches the finished jobs first, then the dialog is open only after the data is ready.
- Added a loading spinner to the refresh icon button during the fetch, providing immediate visual feedback.
- Ensured the dialog resets job selections each time it opens with fresh data fetch, preventing stale selections from persisting across opens.
- If the fetch fails, the dialog doesn't open, and an error notification should be shown instead.

See the gif for demonstration of the UI:
<img width="720" height="521" alt="resetting-jobs" src="https://github.com/user-attachments/assets/b2b8f8c7-4357-417a-bd26-95c6e94b176d" />

