### PR TITLE
feat: allow announce endpoint to accept alternate identifiers

### DIFF
--- a/app/Controllers/Http/ParticipantController.js
+++ b/app/Controllers/Http/ParticipantController.js
@@ -381,7 +381,7 @@ class ParticipantController {
   *         name: identifier
   *         required: true
   *         type: string
-  *         description: The identifier code of the participant.
+  *         description: The identifier (canonical or alternate) of the participant.
   *     responses:
   *       200:
   *         description: Sends the study to perform, including a download link for the osexp file.
@@ -412,7 +412,10 @@ class ParticipantController {
   */
   async announce ({ params, transform, response }) {
     const { identifier } = params
-    const ptcp = await Participant.findByOrFail('identifier', identifier)
+    const ptcp = await Participant.query()
+      .where('identifier', identifier)
+      .orWhere('alternate_identifier', identifier)
+      .firstOrFail()
     if (!ptcp.active) {
       return response.badRequest({ message: 'Participant is not active' })
     }
@@ -845,7 +848,7 @@ class ParticipantController {
   *         name: identifier
   *         required: true
   *         type: string
-  *         description: The identifier of the participant to retrieve
+  *         description: The identifier (canonical or alternate) of the participant to retrieve
   *     responses:
   *       200:
   *         description: The participant's canonical identifier.

--- a/test/functional/study.spec.js
+++ b/test/functional/study.spec.js
@@ -5,6 +5,7 @@ const { test, trait, before } = use('Test/Suite')('Participant Jobs')
 trait('Test/ApiClient')
 
 const PARTICIPANT = 'a'
+const PARTICIPANT_ALT = 'alt_a'
 const STUDY_ID = 1
 
 // Shared state across tests
@@ -160,4 +161,31 @@ test('current job index is back to incremented value', async ({ client, assert }
   assert.isNumber(data.study_id)
   assert.isNumber(data.current_job_index)
   assert.equal(data.current_job_index, currentJobIndex + 1)
+})
+
+test('can announce participant using alternate identifier', async ({ client, assert }) => {
+ 
+  const response = await client
+    .get(`/api/v1/participants/${PARTICIPANT_ALT}/announce`)
+    .end()
+  
+  response.assertStatus(200)
+  const { data } = response.body
+  
+  // Same assertions as the regular announce test
+  assert.isNumber(data.id)
+  assert.isString(data.name)
+  assert.isString(data.description)
+  assert.isNumber(data.jobs_count)
+  assert.isArray(data.files)
+  assert.isArray(data.participants)
+  assert.isAbove(data.participants.length, 0)
+  
+  const participant = data.participants[0]
+  assert.isNumber(participant.id)
+  assert.isString(participant.name)
+  assert.isObject(participant.pivot)
+  assert.isNumber(participant.pivot.participant_id)
+  assert.isNumber(participant.pivot.study_id)
+  assert.isNumber(participant.pivot.status_id)
 })


### PR DESCRIPTION
- Modified ParticipantController to accept both canonical and alternate identifiers
- Added test to verify announce works with alternate_identifier
- Updated Swagger docs to clarify parameter accepts either identifier type

Closes #232 