### PR TITLE
Include participant identifier and alternate_identifier in announce

### DIFF
--- a/app/Controllers/Http/ParticipantController.js
+++ b/app/Controllers/Http/ParticipantController.js
@@ -428,7 +428,7 @@ class ParticipantController {
       .with('participants', (query) => {
         query
           .where('participants.id', ptcp.id)
-          .select(['id', 'name', 'meta'])
+          .select(['id', 'name', 'meta', 'identifier', 'alternate_identifier'])
       })
       .withPivot(['status_id', 'priority'])
       .whereInPivot('status_id', [1, 2]) // participation status 'pending' or 'started'


### PR DESCRIPTION
Although #233 accepted identifier and alternate_identifier, it did not return them, which is necessary in order to implement #33.