### PR TITLE
Fix stats dashboard

### DIFF
--- a/app/Controllers/Http/DashboardController.js
+++ b/app/Controllers/Http/DashboardController.js
@@ -54,7 +54,7 @@ class DashboardController {
               return d
             })
             .reverse()
-        bins = dates.map(d => d.getDate()) 
+        bins = dates.map(d => d.getFullDay()) 
         labels = dates.map(d => d.toLocaleDateString('en-gb', {  weekday: 'long' }))
         break
       case 'month':

--- a/resources/components/Participants/ParticipantsList/ParticipantsList.vue
+++ b/resources/components/Participants/ParticipantsList/ParticipantsList.vue
@@ -174,7 +174,7 @@ export default {
       // This is such an ugly hack, but inevitable with the belongsToMany bug that vuex-orm
       // experiences. Once that is fixed, this hoop is no longer necessary
       const edge = this.Participation.find([studyID, ptcpID])
-      if (!edge.jobs_count) {
+      if (!edge.jobs_count || edge.completed_jobs_count == null) {
         return 0
       }
       return parseInt(edge.completed_jobs_count / edge.jobs_count * 100)

--- a/resources/components/Participants/ParticipationsPanel/ParticipationsPanel.vue
+++ b/resources/components/Participants/ParticipationsPanel/ParticipationsPanel.vue
@@ -36,7 +36,7 @@
                   <v-tooltip bottom>
                     <template #activator="{on, attrs}">
                       <div class="d-inline-block" v-bind="attrs" v-on="on">
-                        <progress-circle :value="progress(item.id, participant.id)" />
+                        <progress-circle :value="progress(item)" />
                       </div>
                     </template>
                     {{ $t('stats.progress') }}
@@ -73,14 +73,12 @@ export default {
     }
   },
   methods: {
-    progress (studyID, ptcpID) {
-      // This is such an ugly hack, but inevitable with the belongsToMany bug that vuex-orm
-      // experiences. Once that is fixed, this hoop is no longer necessary
-      const edge = this.Participation.find([studyID, ptcpID])
-      if (!edge?.jobs_count) {
+    progress (item) {
+      const pivot = item.pivot
+      if (!pivot?.jobs_count || pivot?.completed_jobs_count == null) {
         return 0
       }
-      return parseInt(edge.completed_jobs_count / edge.jobs_count * 100)
+      return parseInt(pivot.completed_jobs_count / pivot.jobs_count * 100)
     },
     names (userList) {
       return userList.map(user => user.name).join(', ')

--- a/resources/models/Participation.js
+++ b/resources/models/Participation.js
@@ -11,6 +11,7 @@ export default class Participation extends Model {
       status_id: this.attr(null),
       priority: this.number(1),
       jobs_count: this.number(0),
+      completed_jobs_count: this.number(0),
       job_results_count: this.number(0),
       loop_count: this.number(0),
       created_at: this.attr(null),


### PR DESCRIPTION
Closes #216

It seems that the dashboard error ("0 trials per day on weekly view only happens the first week of every month") was caused by misalignment of dashboard bins with SQL zero-padded day format. The week trend used d.getDate() (numbers 1-7) while SQL DATE_FORMAT  returns zero-padded strings 01-07. This caused a JS object key lookup mismatch, making all bins in the first week of each month resolve to 0. I tested it with some hard-coded database, and it worked. I hope the issue is resolved. 

The PR also resolves NaN values in participant progress value (a respective method was querying wrong data source: participation instead of study pivot)