### PR TITLE
Fix trial counts in dashboard and study statistics

### DIFF
--- a/app/Controllers/Http/DashboardController.js
+++ b/app/Controllers/Http/DashboardController.js
@@ -157,19 +157,20 @@ class DashboardController {
   async mostActiveStudies ({ request, auth }) {
     const limit = request.input('limit', 1000)
     const days = request.input('days', 7)
-    const data = await JobState.query()
+    
+    const JobResult = use('App/Models/JobResult')
+    
+    const data = await JobResult.query()
       .select(
-        Database.raw('COUNT(*) as participations'),
+        Database.raw('COUNT(*) as participations'),  // Now counts job_results
         'studies.id',
         'studies.name'
       )
-      .leftJoin('jobs', 'job_states.job_id', 'jobs.id')
-      .leftJoin('studies', 'jobs.study_id', 'studies.id')
+      .leftJoin('studies', 'job_results.study_id', 'studies.id')
       .leftJoin('study_users', 'studies.id', 'study_users.study_id')
       .where('study_users.user_id', auth.user.id)
       .where('studies.active', 1)
-      .whereRaw('job_states.updated_at >= DATE_SUB(NOW(), INTERVAL ? DAY)', [days])
-      .whereNot('job_states.status_id', 1) // job state status 'pending'
+      .whereRaw('job_results.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)', [days])
       .groupByRaw('studies.name, studies.id')
       .orderBy('participations', 'desc')
       .limit(limit)
@@ -187,14 +188,16 @@ class DashboardController {
   async mostActiveParticipants ({ request }) {
     const limit = request.input('limit', 1000)
     const days = request.input('days', 7)
-    const data = await JobState.query()
+    
+    const JobResult = use('App/Models/JobResult')
+    
+    const data = await JobResult.query()
       .select('participants.name',
         'participants.identifier',
-        Database.raw('COUNT(*) as participations')
+        Database.raw('COUNT(*) as participations')  // ← Now counts job_results
       )
-      .leftJoin('participants', 'job_states.participant_id', 'participants.id')
-      .whereRaw('job_states.updated_at >= DATE_SUB(NOW(), INTERVAL ? DAY)', [days])
-      .whereNot('job_states.status_id', 1) // job state status 'pending'
+      .leftJoin('participants', 'job_results.participant_id', 'participants.id')
+      .whereRaw('job_results.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)', [days])
       .groupByRaw('name, identifier')
       .orderBy('participations', 'desc')
       .limit(limit)

--- a/app/Controllers/Http/StudyController.js
+++ b/app/Controllers/Http/StudyController.js
@@ -1205,21 +1205,21 @@ class StudyController {
       .firstOrFail()
 
     const ptcpTrend = (await Database.raw(`
-      SELECT SUM(c) AS amount, bin, updated_at
+      SELECT SUM(c) AS amount, bin, created_at
       FROM (
         SELECT
-          job_states.updated_at,
+          job_results.created_at,
           count(*) AS c,
           FLOOR(
             PERCENT_RANK() OVER (
-                ORDER BY job_states.updated_at ASC
+                ORDER BY job_results.created_at ASC
             ) * ?) as bin
-        FROM job_states
-        LEFT JOIN jobs ON job_states.job_id = jobs.id
-        WHERE status_id = 3 AND jobs.study_id = ?
-        GROUP BY job_states.updated_at
+        FROM job_results
+        LEFT JOIN jobs ON job_results.job_id = jobs.id
+        WHERE jobs.study_id = ?
+        GROUP BY job_results.created_at
       ) as bins
-      GROUP BY bin, updated_at
+      GROUP BY bin, created_at
       `, [bins, study.id]))[0]
 
     const trend = processTrend(bins, ptcpTrend)

--- a/app/Util/trend.js
+++ b/app/Util/trend.js
@@ -27,16 +27,15 @@ module.exports = function (bins, dbData) {
     const dayFormat = 'd MMM'
     const timeFormat = 'HH:mm'
 
-    // If all participations are on the same day, show the time at the ends of the axis
-    // with the day in the center. Otherwise, just show the first and last day at the ends
-    // of the axis
-    if (differenceInCalendarDays(last.updated_at, first.updated_at) === 0) {
-      labels[0] = format(first.updated_at, timeFormat)
-      labels[Math.floor(bins / 2)] = format(first.updated_at, dayFormat)
-      labels[bins] = format(last.updated_at, timeFormat)
+    const dateKey = first.updated_at ? 'updated_at' : 'created_at'
+    
+    if (differenceInCalendarDays(last[dateKey], first[dateKey]) === 0) {
+      labels[0] = format(first[dateKey], timeFormat)
+      labels[Math.floor(bins / 2)] = format(first[dateKey], dayFormat)
+      labels[bins] = format(last[dateKey], timeFormat)
     } else {
-      labels[0] = format(first.updated_at, dayFormat)
-      labels[bins] = format(last.updated_at, dayFormat)
+      labels[0] = format(first[dateKey], dayFormat)
+      labels[bins] = format(last[dateKey], dayFormat)
     }
   }
   return {


### PR DESCRIPTION
Changed queries in DashboardController and StudyController to count job_results instead of job_states, ensuring trial counts are based on actual completed trial records.

Closes #216