### PR TITLE
fix: show "Finished" instead of "First to run" for participants with finished jobs

### DIFF
--- a/resources/components/Participants/ParticipantsPanel/StudyParticipantsList/QueueStatus/QueueStatus.vue
+++ b/resources/components/Participants/ParticipantsPanel/StudyParticipantsList/QueueStatus/QueueStatus.vue
@@ -27,6 +27,10 @@ export default {
       type: Number,
       required: true
     },
+    status: {
+      type: Number,
+      default: null
+    },
     loading: {
       type: [String, Number, Boolean],
       default: false
@@ -34,6 +38,9 @@ export default {
   },
   computed: {
     message () {
+      if (this.status === 3) {
+        return this.$t('participants.priority.finished')
+      }
       if (this.position.queue_position > 1) {
         return this.$t('participants.priority.queued') + ` ${this.position.queue_position - 1}`
       } else {
@@ -41,6 +48,9 @@ export default {
       }
     },
     decorations () {
+      if (this.status === 3) {
+        return { class: 'grey--text text--disabled' }
+      }
       return {
         class: this.position.queue_position > 1
           ? 'primary--text'

--- a/resources/components/Participants/ParticipantsPanel/StudyParticipantsList/StudyParticipantsList.vue
+++ b/resources/components/Participants/ParticipantsPanel/StudyParticipantsList/StudyParticipantsList.vue
@@ -25,6 +25,7 @@
               :participant="item.id"
               :loading="loadingQueue"
               :position="queue[item.id]"
+              :status="item.pivot.status_id"
             />
           </v-list-item-content>
           <v-list-item-action v-if="editable" style="max-width: 40px">

--- a/resources/lang/en-US/participants.js
+++ b/resources/lang/en-US/participants.js
@@ -46,7 +46,8 @@ export default {
   },
   priority: {
     queued: 'Queued at position',
-    first: 'First to run'
+    first: 'First to run',
+    finished: 'Finished'
   },
   jobs: {
     reset: {


### PR DESCRIPTION
When participation status changes to finished (status_id=3), the QueueStatus component now displays "Finished" in grey text instead of falling through to the "First to run" message.

Closes #242